### PR TITLE
Improve documentation across repo

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -1,9 +1,17 @@
 # Agents
 
-This package contains the Strands agents that process voice memo transcripts.
+This package contains the Python modules that implement the individual
+agents invoked by the WhisperSync Lambda router.  Each agent receives the
+transcribed text of a voice memo and performs a specialized action.
 
-- `work_journal_agent.py` – appends weekly work journal logs and returns a summary.
-- `memory_agent.py` – archives personal memories as JSON Lines.
-- `github_idea_agent.py` – creates a GitHub repository from a transcript using PyGithub.
+- `work_journal_agent.py` – Appends entries to a weekly work log stored in
+  S3 and returns a short summary confirming the write.
+- `memory_agent.py` – Stores personal memories as JSON Lines files in S3
+  for later analysis.
+- `github_idea_agent.py` – Creates a new GitHub repository from an idea
+  described in the transcript.  Metadata about the repo is also logged to
+  S3.
 
-Each module exposes a `handle(payload: dict)` function used by the Lambda router or Strands platform.
+Every module exposes a ``handle(payload: dict)`` function which the Lambda
+router or Strands platform can call.  The payload always includes the
+transcript text, the target S3 bucket and the source object key.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agent implementations for the WhisperSync system.
+
+Each agent receives a transcript and performs a task such as archiving a
+memory, logging work, or creating a GitHub repository.  The modules
+provide ``handle`` functions consumed by the Lambda router.
+"""

--- a/agents/memory_agent.py
+++ b/agents/memory_agent.py
@@ -1,6 +1,9 @@
 """Memory Agent.
 
-Stores personal memory transcripts as JSON lines in S3 and tags sentiment.
+This module defines an agent that archives short personal memories.  A
+transcript provided by the Lambda router is written to an S3 bucket as a
+single JSON Lines record.  A sentiment field is included as a placeholder
+for future analysis or enhancement.
 """
 from __future__ import annotations
 
@@ -20,7 +23,20 @@ logger.setLevel(logging.INFO)
 s3 = boto3.client("s3") if boto3 else None
 
 def handle(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Archive a memory transcript to S3."""
+    """Archive a memory transcript to S3.
+
+    Parameters
+    ----------
+    payload : dict
+        Should contain ``transcript`` with the memory text and ``bucket``
+        specifying the S3 bucket name.
+
+    Returns
+    -------
+    dict
+        Mapping with the key ``memory_key`` pointing to the stored object
+        path.  When ``boto3`` is not available a dry-run value is returned.
+    """
     transcript = payload.get("transcript", "")
     bucket = payload.get("bucket")
     if s3 is None:

--- a/agents/work_journal_agent.py
+++ b/agents/work_journal_agent.py
@@ -1,6 +1,8 @@
 """Work Journal Agent.
 
-Appends transcripts to a weekly work log stored in S3 and returns a summary.
+This agent appends a transcript to a week-based journal file stored in S3.
+The intent is to capture quick daily notes that can later be summarized.
+Only a short confirmation summary is generated here as a placeholder.
 """
 from __future__ import annotations
 
@@ -18,7 +20,20 @@ logger.setLevel(logging.INFO)
 
 s3 = boto3.client("s3") if boto3 else None
 def handle(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Append transcript to weekly log and return a short summary."""
+    """Append transcript to weekly log and return a short summary.
+
+    Parameters
+    ----------
+    payload : dict
+        Contains ``transcript`` with the work note text and ``bucket`` for
+        the S3 location.
+
+    Returns
+    -------
+    dict
+        Path of the log file and a one-line summary string.  In dry-run
+        mode the log key is ``"dry-run"``.
+    """
     transcript = payload.get("transcript", "")
     bucket = payload.get("bucket")
     if s3 is None:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,9 +1,13 @@
 # Infrastructure
 
-AWS CDK app that provisions the resources for the Voice MCP system:
+AWS CDK app that provisions the resources for the WhisperSync system.
+It builds an S3 bucket and a Lambda function capable of routing
+transcripts to the correct agent.
 
 - S3 bucket `voice-mcp` with notifications on the `transcripts/` prefix
 - Lambda function `mcpAgentRouterLambda` which routes transcripts to Strands agents
 - IAM permissions for S3, Bedrock model invocation, and Secrets Manager access
 
-Run `cdk deploy` inside this directory to deploy the stack.
+Run ``cdk deploy`` from this directory to deploy the stack to your AWS
+account.  The stack is intentionally minimal so it can be extended for
+additional agents or storage locations.

--- a/infrastructure/__init__.py
+++ b/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure deployment package.
+
+This package contains the AWS CDK stack definitions used to provision
+the resources required for the WhisperSync system.
+"""

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+"""CDK application entry point.
+
+This script synthesizes the :class:`~McpStack` which provisions all AWS
+resources for the WhisperSync system.
+"""
+
 import aws_cdk as cdk
 from mcp_stack import McpStack
 

--- a/infrastructure/mcp_stack.py
+++ b/infrastructure/mcp_stack.py
@@ -1,3 +1,5 @@
+"""AWS CDK stack for WhisperSync infrastructure."""
+
 from aws_cdk import (
     Stack,
     aws_s3 as s3,
@@ -10,7 +12,10 @@ from pathlib import Path
 
 
 class McpStack(Stack):
+    """CDK stack that provisions S3, Lambda, and permissions."""
+
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        """Initialize the stack and set up resources."""
         super().__init__(scope, construct_id, **kwargs)
 
         bucket = s3.Bucket(self, "VoiceMcpBucket",

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,5 +1,11 @@
 # Lambda
 
-This folder contains the `router_handler.py` entry point used by AWS Lambda. The function listens for S3 `ObjectCreated` events on the `transcripts/` prefix and routes each transcript to the appropriate Strands agent. Results are written back to `outputs/` in the same bucket.
+This folder contains the ``router_handler.py`` entry point used by the
+deployed Lambda function.  Whenever a transcript text file is uploaded to
+S3 under the ``transcripts/`` prefix, the Lambda downloads that file,
+determines which agent should handle it and invokes the agent.  Responses
+are stored back in the ``outputs/`` prefix.
 
-Use the provided infrastructure stack to deploy this Lambda with the required permissions.
+The Lambda runs with permissions created by the infrastructure stack
+allowing it to read and write from S3, call models via Bedrock and fetch
+secrets for the GitHub agent.

--- a/lambda/__init__.py
+++ b/lambda/__init__.py
@@ -1,0 +1,6 @@
+"""AWS Lambda package for WhisperSync.
+
+Modules in this package are bundled into the Lambda function that
+responds to S3 events and dispatches transcripts to the appropriate
+agent implementation.
+"""

--- a/lambda/router_handler.py
+++ b/lambda/router_handler.py
@@ -1,4 +1,9 @@
-"""Lambda entry point to route transcripts to Strands agents."""
+"""AWS Lambda entry point for dispatching transcripts.
+
+The function triggered by S3 events loads the appropriate agent module
+and either invokes it locally or through the Strands SDK.  Results are
+written back to S3 under the ``outputs/`` prefix.
+"""
 import json
 import logging
 import os

--- a/mac-to-s3/transcribe-and-send.sh
+++ b/mac-to-s3/transcribe-and-send.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
+#
+# Transcribe audio files using Whisper and upload the resulting text
+# to Amazon S3.  Designed to be triggered via an Automator workflow on
+# macOS.
+#
 # Ensure paths to ffmpeg, whisper, and aws CLI are available
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,8 @@
 # Scripts
 
-Utility scripts for local development and Strands integration.
+Utility scripts for local development and integration with the
+Strands platform. They allow you to exercise the agents without
+deploying any AWS infrastructure.
 
 - `local_test_runner.py` – simulates the Lambda by invoking agents on a transcript file
 - `register_agents.py` – helper to register agents with the Strands platform
@@ -10,3 +12,6 @@ Place sample transcripts under `test_data/transcripts/<agent_name>/` and run the
 ```bash
 python scripts/local_test_runner.py test_data/transcripts/work/test.txt
 ```
+
+``register_agents.py`` only needs to be run when a new agent module is
+added or its metadata changes.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Utility command line scripts used during development.
+
+These helpers register agents with the Strands platform and provide a
+local runner for testing the agent workflow without deploying to AWS.
+"""

--- a/scripts/local_test_runner.py
+++ b/scripts/local_test_runner.py
@@ -1,4 +1,9 @@
-"""Local test runner to mimic Lambda invocation."""
+"""Local test runner to mimic Lambda invocation.
+
+This utility imports the Lambda router and executes a selected agent on
+a transcript file.  It is useful for verifying agent behavior without
+deploying any AWS resources.
+"""
 from __future__ import annotations
 
 import json
@@ -14,7 +19,15 @@ invoke_agent = import_module("lambda.router_handler").invoke_agent
 
 
 def main(path: str, bucket: str = "local-bucket") -> None:
-    """Execute the selected agent with a local transcript file."""
+    """Execute the selected agent with a local transcript file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the transcript text file.
+    bucket : str, optional
+        Name of the mock S3 bucket to pass to the agent.
+    """
     path_obj = Path(path)
     key = str(path_obj)
     parts = path_obj.parts

--- a/scripts/register_agents.py
+++ b/scripts/register_agents.py
@@ -1,4 +1,8 @@
-"""Register agents with Strands platform."""
+"""Register agents with the Strands platform.
+
+Running this script will create or update agent records so that the
+platform knows how to invoke the local implementation modules.
+"""
 from strands_sdk import register_agent
 
 register_agent(

--- a/test_data/README.md
+++ b/test_data/README.md
@@ -1,3 +1,6 @@
 # Test Data
 
-Example transcripts used for local testing. Files are organized under `transcripts/<agent_name>/` to mirror the S3 layout expected by the Lambda function.
+Example transcripts used for local testing. Files are organized under
+``transcripts/<agent_name>/`` to mirror the S3 layout expected by the
+Lambda function.  The ``local_test_runner.py`` script reads from this
+directory when simulating a Lambda invocation.

--- a/test_data/transcripts/README.md
+++ b/test_data/transcripts/README.md
@@ -1,0 +1,4 @@
+This folder mirrors the structure of the S3 ``transcripts/`` prefix used
+by the Lambda router.  Each subdirectory is named after an agent and
+contains plain text files that represent example voice memo
+transcriptions.

--- a/test_data/transcripts/work/README.md
+++ b/test_data/transcripts/work/README.md
@@ -1,0 +1,1 @@
+Sample transcripts for the ``work`` agent.


### PR DESCRIPTION
## Summary
- add file-level and function-level docstrings for agents and infrastructure
- document Lambda router, scripts and macOS transcription script
- expand directory READMEs with more detailed explanations
- add README files for test transcripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848cd44e26c832aadcb23d080dd5e66