### PR TITLE
Align agent tools with Strands guidelines

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -12,6 +12,8 @@ transcribed text of a voice memo and performs a specialized action.
   described in the transcript.  Metadata about the repo is also logged to
   S3.
 
-Every module exposes a ``handle(payload: dict)`` function which the Lambda
-router or Strands platform can call.  The payload always includes the
-transcript text, the target S3 bucket and the source object key.
+Each module exposes a ``handle`` function decorated with ``@tool``. The
+function parameters are individually typed (e.g. ``transcript: str`` and
+``bucket: str``) so the Strands framework can derive a tool specification
+automatically. These functions can be invoked directly with keyword
+arguments or via the ``Agent`` class.

--- a/lambda/router_handler.py
+++ b/lambda/router_handler.py
@@ -52,7 +52,7 @@ def invoke_agent(agent_name: str, payload: dict) -> dict:
             logger.exception("Strands agent execution failed")
 
     if hasattr(module, "handle"):
-        return module.handle(payload)
+        return module.handle(**payload)
 
     raise AttributeError(f"Agent {agent_name} missing handle()")
 


### PR DESCRIPTION
## Summary
- refactor tools to declare parameters explicitly and set tool names
- return structured ToolResult dictionaries
- update router to call updated functions
- clarify agent README about `@tool` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684968811548832a8ce4e46db29028c1