### PR TITLE
Add docs for async streaming and callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,25 +140,24 @@ Place transcript in test_data/transcripts/work/2025-06-09_1230.txt
 
 Run:
 
-bash
-Copy
-Edit
+```bash
 python local_test_runner.py transcripts/work/2025-06-09_1230.txt
-This mimics the Lambda + S3 pipeline and prints the result.
+```
+Use `--stream` to stream events and `--callback` to enable the demo callback
+handler. This mimics the Lambda + S3 pipeline and prints the result.
 
 📓 Logs & Output
 Processed agent responses go to:
 
-bash
-Copy
-Edit
+```
 s3://<YOUR_BUCKET>/outputs/{agent}/{date}_response.json
+```
+
 Agent history (optional) written to:
 
-perl
-Copy
-Edit
+```
 s3://<YOUR_BUCKET>/{agent}/history.jsonl
+```
 
 ## 🌀 Streaming Responses with Async Iterators
 


### PR DESCRIPTION
## Summary
- document async iterators for streaming agent events
- add explanation and example of callback handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684968e545b0832a8d6cc831b90cf29b