### PR TITLE
Add integration tests

### DIFF
--- a/test_data/transcripts/github_ideas/README.md
+++ b/test_data/transcripts/github_ideas/README.md
@@ -1,0 +1,1 @@
+Sample transcripts for the `github_ideas` agent.

--- a/test_data/transcripts/github_ideas/test.txt
+++ b/test_data/transcripts/github_ideas/test.txt
@@ -1,0 +1,1 @@
+An idea to build an AI-powered plant watering system.

--- a/test_data/transcripts/memories/README.md
+++ b/test_data/transcripts/memories/README.md
@@ -1,0 +1,1 @@
+Sample transcripts for the `memories` agent.

--- a/test_data/transcripts/memories/test.txt
+++ b/test_data/transcripts/memories/test.txt
@@ -1,0 +1,1 @@
+A happy day at the park.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,58 @@
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+import pytest
+
+# Provide a minimal stub for the ``strands`` package so agent modules can load
+strands_stub = types.ModuleType("strands")
+def _tool(**_kwargs):
+    def decorator(func):
+        return func
+    return decorator
+strands_stub.tool = _tool
+sys.modules.setdefault("strands", strands_stub)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+router_handler = importlib.import_module("lambda.router_handler")
+
+invoke_agent = router_handler.invoke_agent
+stream_agent_async = router_handler.stream_agent_async
+
+@pytest.mark.parametrize(
+    "agent,transcript,expected_field",
+    [
+        ("work", "Today I worked on the project.", "log_key"),
+        ("memories", "A happy day at the park.", "memory_key"),
+        ("github_ideas", "An idea to build an AI-powered plant watering system.", "repo"),
+    ],
+)
+def test_invoke_agent(agent, transcript, expected_field):
+    payload = {
+        "transcript": transcript,
+        "bucket": "test-bucket",
+    }
+    if agent == "github_ideas":
+        payload["source_s3_key"] = f"transcripts/{agent}/test.txt"
+    result = invoke_agent(agent, payload)
+    assert result["status"] == "success"
+    assert expected_field in result["content"][0]["json"]
+
+
+def test_stream_agent_async_fallback():
+    payload = {
+        "transcript": "Streaming integration test",
+        "bucket": "test-bucket",
+    }
+
+    async def collect():
+        events = []
+        async for event in stream_agent_async("work", payload):
+            events.append(event)
+        return events
+
+    events = asyncio.run(collect())
+    assert events[-1]["complete"] is True
+    assert events[-1]["data"]["status"] == "success"


### PR DESCRIPTION
## Summary
- add example transcripts for `memories` and `github_ideas`
- add `tests/test_integration.py` covering router invocation and async streaming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496ade5c34832a8b21d54757d1db6b